### PR TITLE
Fix according the return from the API

### DIFF
--- a/swagger/en/schemas/gameModeStats.yml
+++ b/swagger/en/schemas/gameModeStats.yml
@@ -18,6 +18,8 @@ properties:
     type: integer
   heals:
     type: integer
+  killPoints:
+    type: number
   kills:
     type: integer
   longestKill:
@@ -52,13 +54,11 @@ properties:
     type: integer
   walkDistance:
     type: number
-  weaponAcquired:
+  weaponsAcquired:
     type: integer
   weeklyKills:
     type: integer
   winPoints:
-    type: number
-  winRatio:
     type: number
   wins:
     type: integer


### PR DESCRIPTION
According the result of the following request :

> https://api.playbattlegrounds.com/shards/pc-na/players/account.d50fdc18fcad49c691d38466bed6f8fd/seasons/division.bro.official.2018-04

I found some errors in the documentation of the attributes of the gameModeStats object : 

- killPoints attribute is missing in the documentation
- weaponsAcquired in the result vs weaponAcquired in the documentation
- winRatio is missing in the result