### PR TITLE
New telemetry data

### DIFF
--- a/rst/telemetry-events.rst
+++ b/rst/telemetry-events.rst
@@ -192,6 +192,7 @@ LogPlayerKill
   "victim":             {Character},
   "damageTypeCategory": string,
   "damageCauserName":   string,
+  "damageReason":       string,
   "distance":           number
 
 
@@ -267,7 +268,8 @@ PC only
 
 .. code-block:: none
 
-  "character": {Character}
+  "character": {Character},
+  "swimDistance": float
 
 
 
@@ -285,3 +287,34 @@ PC only
   "damageCauserName":   string,
   "item":               {Item},
   "distance":           number
+
+
+
+LogWheelDestroy
+---------------
+PC only
+
+.. code-block:: none
+
+  "attackId":           int,
+  "attacker":           {Character},
+  "vehicle":            {Vehicle},
+  "damageTypeCategory": string,
+  "damageCauserName":   string
+
+
+
+LogPlayerMakeGroggy
+-------------------
+PC only
+
+.. code-block:: none
+
+  "attackId":            int,
+  "attacker":            {Character},
+  "victim":              {Character},
+  "damageTypeCategory":  string,
+  "damageCauserName":    string,
+  "distance":            float,
+  "isAttackerInVehicle": bool,
+  "dBNOId":              int

--- a/rst/telemetry-events.rst
+++ b/rst/telemetry-events.rst
@@ -318,3 +318,14 @@ PC only
   "distance":            float,
   "isAttackerInVehicle": bool,
   "dBNOId":              int
+
+
+
+LogPlayerRevive
+---------------
+PC only
+
+.. code-block:: none
+
+  "reviver":             {Character},
+  "victim":              {Character}, // Yes, it's actually called victim

--- a/rst/telemetry-events.rst
+++ b/rst/telemetry-events.rst
@@ -112,9 +112,11 @@ LogMatchStart
   "mapName":               string,
   "weatherId":             string,
   "characters":            [{Character}, ...],
-  "cameraViewBehaviour":   string,             // Custom match only
-  "teamSize":              int,                // Custom match only
-  "blueZoneCustomOptions": string              // Custom match only
+  "cameraViewBehaviour":   string,             
+  "teamSize":              int,
+  "isCustomGame":          bool,
+  "isEventMode":           bool,                
+  "blueZoneCustomOptions": string              
 
 blueZoneCustomOptions is a stringified array of objects. See :ref:`blueZoneCustomOptions`.
 

--- a/swagger/en/schemas/match.yml
+++ b/swagger/en/schemas/match.yml
@@ -25,7 +25,7 @@ properties:
       mapName:
         type: string
         description: "Map name"
-        enum: [Desert_Main, Erangel_Main]
+        enum: [Desert_Main, Erangel_Main, Savage_Main]
       isCustomMatch:
         type: boolean
         description: "True if this match is a custom match"


### PR DESCRIPTION
Adds:
- Sanhok map to mapName enum
- `LogPlayerMakeGroggy`, `LogPlayerRevive`, and `LogWheelDestroy` events
- `swimDistance` to `LogSwimEnd` events
- `isCustomGame` and `isEventMode` to LogMatchStart
- `damageReason` to `LogPlayerKill`