### PR TITLE
v21.2 patch12.2

### DIFF
--- a/rst/changelog/changelog.rst
+++ b/rst/changelog/changelog.rst
@@ -12,6 +12,18 @@ No planned changes at the moment. To subscribe to our mailing list for changelog
 
 .. To subscribe to our mailing list for changelog updates, `click here <http://eepurl.com/dFPTNL>`_.
 
+
+
+v21.1.0
+--------
+
+New Data:
+
+- LogPlayerRedeploy
+- LogPlayerRedeployBRStart
+
+
+
 v21.0.0
 --------
 

--- a/rst/known-issues.rst
+++ b/rst/known-issues.rst
@@ -30,12 +30,6 @@ The number of grenades and smoke bombs dropped may sometimes exceed the number o
 
 
 
-victim.location for LogPlayerTakeDamage events are sometimes 0
----------------------------------------------------------------
-The values for LogPlayerTakeDamage.victim.location may be 0 when damageTypeCategory is "Damage_Groggy".
-
-
-
 Item_Weapon_vz61Skorpion_C and Item_Weapon_FlareGun_C are listed with the subCategory "Main"
 ---------------------------------------------------------------------------------------------
 Item_Weapon_vz61Skorpion_C and Item_Weapon_FlareGun_C are listed in the telemetry with the subCategory "Main" instead of "Handgun" for log events.

--- a/rst/telemetry-events.rst
+++ b/rst/telemetry-events.rst
@@ -384,6 +384,22 @@ LogPlayerPosition
 
 
 
+LogPlayerRedeploy
+------------------
+.. code-block:: none
+
+  "character":  {Character},
+
+
+
+LogPlayerRedeployBRStart
+-------------------------
+.. code-block:: none
+
+  "characters": [{Character}, ...],
+
+
+
 LogPlayerRevive
 ---------------
 .. code-block:: none


### PR DESCRIPTION
- add LogPlayerRedeploy
- add LogPlayerRedeployBRStart
- remove known issue "victim.location for LogPlayerTakeDamage events are sometimes 0" (resolved in previous game patch)