### PR TITLE
Updated MapSize for Vikend

### DIFF
--- a/rst/telemetry-objects.rst
+++ b/rst/telemetry-objects.rst
@@ -187,8 +187,8 @@ Location
 
 - Location values are measured in centimeters.
 - (0,0) is at the top-left of each map.
-- The range for the X and Y axes is 0 - 816,000 for Erangel, Miramar, Taego and Deston.
-- The range for the X and Y axes is 0 - 612,000 for Vikendi.
+- The range for the X and Y axes is 0 - 816,000 for Erangel, Miramar, Taego, Deston and Vikendi (since patch 21.1).
+- The range for the X and Y axes is 0 - 612,000 for Vikendi (up to patch 20.2).
 - The range for the X and Y axes is 0 - 408,000 for Sanhok.
 - The range for the X and Y axes is 0 - 306,000 for Paramo.
 - The range for the X and Y axes is 0 - 204,000 for Karakin and Range.


### PR DESCRIPTION
Vikendi got reworked with Patch 21.1 and changed it's size from 6x6 to 8x8.